### PR TITLE
Survey

### DIFF
--- a/CoughSync.xcodeproj/project.pbxproj
+++ b/CoughSync.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		2FE5DCB129EE6107004B9AB4 /* AccountOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE5DCAC29EE6107004B9AB4 /* AccountOnboarding.swift */; };
 		2FF53D8D2A8729D600042B76 /* CoughSyncStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF53D8C2A8729D600042B76 /* CoughSyncStandard.swift */; };
 		492845522D4AB56800C737C8 /* CoughBurdenQuestionnaire.json in Resources */ = {isa = PBXBuildFile; fileRef = 492845512D4AB56700C737C8 /* CoughBurdenQuestionnaire.json */; };
+		49F06F512D4EDE1500A7E170 /* CoughBurdenQuestionnaire.json.license in Resources */ = {isa = PBXBuildFile; fileRef = 49F06F502D4EDDF700A7E170 /* CoughBurdenQuestionnaire.json.license */; };
 		5680DD3E2AB8CD84004E6D4A /* ContributionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680DD3D2AB8CD84004E6D4A /* ContributionsTest.swift */; };
 		56E708352BB06B7100B08F0A /* SpeziLicense in Frameworks */ = {isa = PBXBuildFile; productRef = 56E708342BB06B7100B08F0A /* SpeziLicense */; };
 		56E7083B2BB06F6F00B08F0A /* SwiftPackageList in Frameworks */ = {isa = PBXBuildFile; productRef = 56E7083A2BB06F6F00B08F0A /* SwiftPackageList */; };
@@ -119,6 +120,7 @@
 		2FE5DCAC29EE6107004B9AB4 /* AccountOnboarding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountOnboarding.swift; sourceTree = "<group>"; };
 		2FF53D8C2A8729D600042B76 /* CoughSyncStandard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoughSyncStandard.swift; sourceTree = "<group>"; };
 		492845512D4AB56700C737C8 /* CoughBurdenQuestionnaire.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CoughBurdenQuestionnaire.json; sourceTree = "<group>"; };
+		49F06F502D4EDDF700A7E170 /* CoughBurdenQuestionnaire.json.license */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoughBurdenQuestionnaire.json.license; sourceTree = "<group>"; };
 		5680DD3D2AB8CD84004E6D4A /* ContributionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributionsTest.swift; sourceTree = "<group>"; };
 		653A254D283387FE005D4D48 /* CoughSync.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CoughSync.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A2550283387FE005D4D48 /* CoughSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoughSync.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 		2FE5DC2D29EDD792004B9AB4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				49F06F502D4EDDF700A7E170 /* CoughBurdenQuestionnaire.json.license */,
 				492845512D4AB56700C737C8 /* CoughBurdenQuestionnaire.json */,
 				2FE5DC2A29EDD78D004B9AB4 /* AppIcon.png */,
 				653A255428338800005D4D48 /* Assets.xcassets */,
@@ -504,6 +507,7 @@
 				2FC3439229EE634B002D773C /* ConsentDocument.md in Resources */,
 				2FC3439129EE6349002D773C /* AppIcon.png in Resources */,
 				653A255528338800005D4D48 /* Assets.xcassets in Resources */,
+				49F06F512D4EDE1500A7E170 /* CoughBurdenQuestionnaire.json.license in Resources */,
 				2FC3439029EE6346002D773C /* SocialSupportQuestionnaire.json in Resources */,
 				2FA0BFED2ACC977500E0EF83 /* Localizable.xcstrings in Resources */,
 				492845522D4AB56800C737C8 /* CoughBurdenQuestionnaire.json in Resources */,

--- a/CoughSync.xcodeproj/project.pbxproj
+++ b/CoughSync.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2FE5DC9C29EDD9EF004B9AB4 /* XCTHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC9B29EDD9EF004B9AB4 /* XCTHealthKit */; };
 		2FE5DCB129EE6107004B9AB4 /* AccountOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE5DCAC29EE6107004B9AB4 /* AccountOnboarding.swift */; };
 		2FF53D8D2A8729D600042B76 /* CoughSyncStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF53D8C2A8729D600042B76 /* CoughSyncStandard.swift */; };
+		492845522D4AB56800C737C8 /* CoughBurdenQuestionnaire.json in Resources */ = {isa = PBXBuildFile; fileRef = 492845512D4AB56700C737C8 /* CoughBurdenQuestionnaire.json */; };
 		5680DD3E2AB8CD84004E6D4A /* ContributionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680DD3D2AB8CD84004E6D4A /* ContributionsTest.swift */; };
 		56E708352BB06B7100B08F0A /* SpeziLicense in Frameworks */ = {isa = PBXBuildFile; productRef = 56E708342BB06B7100B08F0A /* SpeziLicense */; };
 		56E7083B2BB06F6F00B08F0A /* SwiftPackageList in Frameworks */ = {isa = PBXBuildFile; productRef = 56E7083A2BB06F6F00B08F0A /* SwiftPackageList */; };
@@ -117,6 +118,7 @@
 		2FE5DC5529EDD811004B9AB4 /* SocialSupportQuestionnaire.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SocialSupportQuestionnaire.json; sourceTree = "<group>"; };
 		2FE5DCAC29EE6107004B9AB4 /* AccountOnboarding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountOnboarding.swift; sourceTree = "<group>"; };
 		2FF53D8C2A8729D600042B76 /* CoughSyncStandard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoughSyncStandard.swift; sourceTree = "<group>"; };
+		492845512D4AB56700C737C8 /* CoughBurdenQuestionnaire.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CoughBurdenQuestionnaire.json; sourceTree = "<group>"; };
 		5680DD3D2AB8CD84004E6D4A /* ContributionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributionsTest.swift; sourceTree = "<group>"; };
 		653A254D283387FE005D4D48 /* CoughSync.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CoughSync.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A2550283387FE005D4D48 /* CoughSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoughSync.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 		2FE5DC2D29EDD792004B9AB4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				492845512D4AB56700C737C8 /* CoughBurdenQuestionnaire.json */,
 				2FE5DC2A29EDD78D004B9AB4 /* AppIcon.png */,
 				653A255428338800005D4D48 /* Assets.xcassets */,
 				2FE5DC2C29EDD78E004B9AB4 /* ConsentDocument.md */,
@@ -503,6 +506,7 @@
 				653A255528338800005D4D48 /* Assets.xcassets in Resources */,
 				2FC3439029EE6346002D773C /* SocialSupportQuestionnaire.json in Resources */,
 				2FA0BFED2ACC977500E0EF83 /* Localizable.xcstrings in Resources */,
+				492845522D4AB56800C737C8 /* CoughBurdenQuestionnaire.json in Resources */,
 				2F6025CB29BBE70F0045459E /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -693,11 +697,11 @@
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This message should never appear. Please adjust this when you start using microphone information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMotionUsageDescription = "This message should never appear. Please adjust this when you start using motion information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This message should never appear. Please adjust this when you start using speecg information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -897,11 +901,11 @@
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This message should never appear. Please adjust this when you start using microphone information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMotionUsageDescription = "This message should never appear. Please adjust this when you start using motion information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This message should never appear. Please adjust this when you start using speecg information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -944,11 +948,11 @@
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This message should never appear. Please adjust this when you start using microphone information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMotionUsageDescription = "This message should never appear. Please adjust this when you start using motion information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This message should never appear. Please adjust this when you start using speecg information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/CoughSync/Resources/CoughBurdenQuestionnaire.json
+++ b/CoughSync/Resources/CoughBurdenQuestionnaire.json
@@ -1,0 +1,237 @@
+{
+  "resourceType": "Questionnaire",
+  "title": "Cough Burden Check-In",
+  "id": "coughburden",
+  "name": "CoughBurden",
+  "description": "This survey asseses the cough burden profile.",
+  "resourceType": "Questionnaire",
+  "language": "en-US",
+  "version": "1",
+  "status": "draft",
+  "publisher": "RAND Corp",
+  "meta": {
+    "profile": [
+      "http://spezi.health/fhir/StructureDefinition/sdf-Questionnaire"
+    ],
+    "tag": [
+      {
+        "system": "urn:ietf:bcp:47",
+        "code": "en-US",
+        "display": "English"
+      }
+    ]
+  },
+  "useContext": [
+    {
+      "code": {
+        "system": "http://hl7.org/fhir/ValueSet/usage-context-type",
+        "code": "focus",
+        "display": "Clinical Focus"
+      },
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "urn:oid:2.16.578.1.12.4.1.1.8655",
+            "display": "Cough Burden Profile"
+          }
+        ]
+      }
+    }
+  ],
+  "contact": [
+    {}
+  ],
+  "subjectType": [
+    "Patient"
+  ],
+  "id": "coughburden",
+  "item": [
+    {
+      "linkId": "80dc8153-5b61-4b1c-8dda-e9ebeaa63fc7",
+      "type": "choice",
+      "text": "How Much Does Your Cough Affect You?",
+      "required": true,
+      "answerOption": [
+        {
+          "valueCoding": {
+            "id": "8e37892c-2f54-4912-8be0-6c9124570642",
+            "code": "0",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "0 - No Burden"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "b764ebc3-25de-4f02-c658-d27d6827a850",
+            "code": "1",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "1 - Minimally"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "230770c1-a162-4a52-9afe-f21e34740a5f",
+            "code": "2",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "2 - Mildly"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "2231e817-6b25-4ac3-bc56-6e76199a0494",
+            "code": "3",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "3 - Moderately"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "0826f1f9-ebce-4c36-8f3f-09931c343e3a",
+            "code": "4",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "4 - Significantly"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "f2209262-7690-49e8-8454-639fef4bef99",
+            "code": "5",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "5 - Extremely"
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://helsenorge.no/fhir/StructureDefinition/sdf-sublabel",
+          "valueMarkdown": "Where 1 represents low and 5 high severity."
+        }
+      ]
+    },
+    {
+      "linkId": "e61212d0-2522-4f3c-faba-73bb9044c357",
+      "type": "choice",
+      "text": "Which of the following factors trigger or worsen your cough? (Select all that apply)",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ValueSet/questionnaire-item-control",
+                "code": "check-box"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://helsenorge.no/fhir/StructureDefinition/sdf-sublabel",
+          "valueMarkdown": "Select all that apply"
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "id": "e17de663-b884-4eae-8104-18b16cbf5268",
+            "code": "air-pollution",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Air pollution"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "18c88d31-8384-4f44-9f7c-6bfc095b17ac",
+            "code": "cold-weather",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Cold weather"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "f770be51-52eb-47c9-eca5-3b24ceaeb9b6",
+            "code": "dust-or-allergens",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Dust or allergens"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "384dc0d1-36a2-460e-a47f-5eaa70ca5d94",
+            "code": "exercise",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Exercise"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "f1358fe5-6a19-4866-921c-d37e3d531e7a",
+            "code": "pollen",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Pollen"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "8dd2f7e9-d759-4e14-85a3-51bb935ca434",
+            "code": "smoke",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Smoke"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "c3c06e22-b39e-4948-97a3-84eac152f294",
+      "type": "open-choice",
+      "text": "How has your cough impacted your quality of life? (Select all that apply)",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "id": "060145ac-5648-47df-f044-45ced094af05",
+            "code": "limitations-in-performing-usual-household-activities",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Limitations in performing usual household activities"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "7375da5a-8374-484d-8ea7-54a490ebeac1",
+            "code": "limitations-in-engaging-in-strenuous-physical-activities",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Limitations in engaging in strenuous physical activities"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "cca84c40-bbd6-4058-e4c6-5c24e42a899e",
+            "code": "limitations-in-participating-in-social-interactions",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Limitations in participating in social interactions"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "512e1a09-7c1f-4cb0-85e6-a74de883cd65",
+            "code": "difficulty-falling-asleep-due-to-coughing",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Difficulty falling asleep due to coughing"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "870c9fd4-819e-4107-b61a-6c912c619fcd",
+            "code": "sleep-disturbances-caused-by-coughing",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Sleep disturbances caused by coughing"
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://helsenorge.no/fhir/StructureDefinition/sdf-sublabel",
+          "valueMarkdown": "Select all that apply"
+        }
+      ]
+    }
+  ]
+}

--- a/CoughSync/Resources/CoughBurdenQuestionnaire.json
+++ b/CoughSync/Resources/CoughBurdenQuestionnaire.json
@@ -1,8 +1,8 @@
 {
   "resourceType": "Questionnaire",
-  "title": "Cough Burden Check-In",
-  "id": "coughburden",
-  "name": "CoughBurden",
+  "title": "Cough Sync",
+  "id": "coughsync",
+  "name": "CoughSync",
   "description": "This survey asseses the cough burden profile.",
   "resourceType": "Questionnaire",
   "language": "en-US",
@@ -49,63 +49,71 @@
     {
       "linkId": "80dc8153-5b61-4b1c-8dda-e9ebeaa63fc7",
       "type": "choice",
-      "text": "How Much Does Your Cough Affect You?",
-      "required": true,
+      "text": "In the last 2 weeks, how many times a day have you had coughing bouts?",
       "answerOption": [
         {
           "valueCoding": {
             "id": "8e37892c-2f54-4912-8be0-6c9124570642",
-            "code": "0",
+            "code": "1---all-of-the-time",
             "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
-            "display": "0 - No Burden"
+            "display": "1 - All of the time"
           }
         },
         {
           "valueCoding": {
             "id": "b764ebc3-25de-4f02-c658-d27d6827a850",
-            "code": "1",
+            "code": "2---most-of-the-time",
             "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
-            "display": "1 - Minimally"
+            "display": "2 - Most of the time"
           }
         },
         {
           "valueCoding": {
             "id": "230770c1-a162-4a52-9afe-f21e34740a5f",
-            "code": "2",
+            "code": "3---several-times-during-the-day",
             "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
-            "display": "2 - Mildly"
+            "display": "3 - Several times during the day"
           }
         },
         {
           "valueCoding": {
             "id": "2231e817-6b25-4ac3-bc56-6e76199a0494",
-            "code": "3",
+            "code": "4---some-times-during-the-day",
             "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
-            "display": "3 - Moderately"
+            "display": "4 - Some times during the day"
           }
         },
         {
           "valueCoding": {
             "id": "0826f1f9-ebce-4c36-8f3f-09931c343e3a",
-            "code": "4",
+            "code": "5---occasionally-through-the-day",
             "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
-            "display": "4 - Significantly"
+            "display": "5 - Occasionally through the day"
           }
         },
         {
           "valueCoding": {
             "id": "f2209262-7690-49e8-8454-639fef4bef99",
-            "code": "5",
+            "code": "6---rarely",
             "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
-            "display": "5 - Extremely"
+            "display": "6 - Rarely"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "f7240412-f1a8-42ea-98cf-8e497c19f856",
+            "code": "7---none",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "7 - None"
           }
         }
-      ]
+      ],
+      "required": true
     },
     {
       "linkId": "e61212d0-2522-4f3c-faba-73bb9044c357",
       "type": "choice",
-      "text": "Which of the following factors trigger or worsen your cough? (Select all that apply)",
+      "text": "In the last 2 weeks, which of the following factors triggered or worsened your cough?",
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -171,61 +179,193 @@
       ]
     },
     {
-      "linkId": "c3c06e22-b39e-4948-97a3-84eac152f294",
-      "type": "open-choice",
-      "text": "How has your cough impacted your quality of life?",
+      "linkId": "81ad20e6-d2a7-48c3-866d-5240bf1d6868",
+      "type": "choice",
+      "text": "In the last 2 weeks, have you had a lot of energy?",
+      "required": true,
       "answerOption": [
         {
           "valueCoding": {
-            "id": "060145ac-5648-47df-f044-45ced094af05",
-            "code": "limitations-in-performing-usual-household-activities",
-            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
-            "display": "Limitations in performing usual household activities"
+            "id": "ec30bad0-bed4-4b9d-8b86-769b43884426",
+            "code": "1",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "1 - All of the time"
           }
         },
         {
           "valueCoding": {
-            "id": "7375da5a-8374-484d-8ea7-54a490ebeac1",
-            "code": "limitations-in-engaging-in-strenuous-physical-activities",
-            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
-            "display": "Limitations in engaging in strenuous physical activities"
+            "id": "1cd6b4d2-3dcb-4af0-804b-9402b5d2eca4",
+            "code": "2",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "2 - Most of the time"
           }
         },
         {
           "valueCoding": {
-            "id": "cca84c40-bbd6-4058-e4c6-5c24e42a899e",
-            "code": "limitations-in-participating-in-social-interactions",
-            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
-            "display": "Limitations in participating in social interactions"
+            "id": "77f68c62-e1a1-43c4-fc4d-7dd3eea9086c",
+            "code": "3",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "3 - A good bit of the time"
           }
         },
         {
           "valueCoding": {
-            "id": "512e1a09-7c1f-4cb0-85e6-a74de883cd65",
-            "code": "difficulty-falling-asleep-due-to-coughing",
-            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
-            "display": "Difficulty falling asleep due to coughing"
+            "id": "a8b414a2-cc78-4054-89f4-00e72e258826",
+            "code": "4",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "4 - Some of the time"
           }
         },
         {
           "valueCoding": {
-            "id": "870c9fd4-819e-4107-b61a-6c912c619fcd",
-            "code": "sleep-disturbances-caused-by-coughing",
-            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
-            "display": "Sleep disturbances caused by coughing"
+            "id": "6360cf9a-7ecc-4594-9de0-d825ea5fa14b",
+            "code": "5",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "5 - A little of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "cef80cd5-3873-4d9a-8f63-ecf6977e3d1e",
+            "code": "6",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "6 - Hardly any of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "de519e9a-32bf-44a1-b4ca-0abf1ad5a22d",
+            "code": "7",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "7 - None of the time"
           }
         }
-      ],
-      "extension": [
+      ]
+    },
+    {
+      "linkId": "c7495877-a09a-47cb-9968-e9606a06eae2",
+      "type": "choice",
+      "text": "In the last 2 weeks, has your cough disturbed your sleep?",
+      "required": true,
+      "answerOption": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://hl7.org/fhir/ValueSet/questionnaire-item-control",
-                "code": "check-box"
-              }
-            ]
+          "valueCoding": {
+            "id": "ec30bad0-bed4-4b9d-8b86-769b43884426",
+            "code": "1",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "1 - All of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "1cd6b4d2-3dcb-4af0-804b-9402b5d2eca4",
+            "code": "2",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "2 - Most of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "77f68c62-e1a1-43c4-fc4d-7dd3eea9086c",
+            "code": "3",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "3 - A good bit of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "a8b414a2-cc78-4054-89f4-00e72e258826",
+            "code": "4",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "4 - Some of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "6360cf9a-7ecc-4594-9de0-d825ea5fa14b",
+            "code": "5",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "5 - A little of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "cef80cd5-3873-4d9a-8f63-ecf6977e3d1e",
+            "code": "6",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "6 - Hardly any of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "de519e9a-32bf-44a1-b4ca-0abf1ad5a22d",
+            "code": "7",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "7 - None of the time"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "b75315dc-db15-4e0c-8235-82f956b4b211",
+      "type": "choice",
+      "text": "In the last 2 weeks, my cough has interfered with my job, or other daily tasks.",
+      "required": true,
+      "answerOption": [
+        {
+          "valueCoding": {
+            "id": "ec30bad0-bed4-4b9d-8b86-769b43884426",
+            "code": "1",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "1 - All of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "1cd6b4d2-3dcb-4af0-804b-9402b5d2eca4",
+            "code": "2",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "2 - Most of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "77f68c62-e1a1-43c4-fc4d-7dd3eea9086c",
+            "code": "3",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "3 - A good bit of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "a8b414a2-cc78-4054-89f4-00e72e258826",
+            "code": "4",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "4 - Some of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "6360cf9a-7ecc-4594-9de0-d825ea5fa14b",
+            "code": "5",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "5 - A little of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "cef80cd5-3873-4d9a-8f63-ecf6977e3d1e",
+            "code": "6",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "6 - Hardly any of the time"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "de519e9a-32bf-44a1-b4ca-0abf1ad5a22d",
+            "code": "7",
+            "system": "urn:uuid:2134d3f1-c6fe-4ff8-accf-868c02da0948",
+            "display": "7 - None of the time"
           }
         }
       ]

--- a/CoughSync/Resources/CoughBurdenQuestionnaire.json
+++ b/CoughSync/Resources/CoughBurdenQuestionnaire.json
@@ -1,0 +1,234 @@
+{
+  "resourceType": "Questionnaire",
+  "title": "Cough Burden Check-In",
+  "id": "coughburden",
+  "name": "CoughBurden",
+  "description": "This survey asseses the cough burden profile.",
+  "resourceType": "Questionnaire",
+  "language": "en-US",
+  "version": "1",
+  "status": "draft",
+  "publisher": "RAND Corp",
+  "meta": {
+    "profile": [
+      "http://spezi.health/fhir/StructureDefinition/sdf-Questionnaire"
+    ],
+    "tag": [
+      {
+        "system": "urn:ietf:bcp:47",
+        "code": "en-US",
+        "display": "English"
+      }
+    ]
+  },
+  "useContext": [
+    {
+      "code": {
+        "system": "http://hl7.org/fhir/ValueSet/usage-context-type",
+        "code": "focus",
+        "display": "Clinical Focus"
+      },
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "urn:oid:2.16.578.1.12.4.1.1.8655",
+            "display": "Cough Burden Profile"
+          }
+        ]
+      }
+    }
+  ],
+  "contact": [
+    {}
+  ],
+  "subjectType": [
+    "Patient"
+  ],
+  "id": "coughburden",
+  "item": [
+    {
+      "linkId": "80dc8153-5b61-4b1c-8dda-e9ebeaa63fc7",
+      "type": "choice",
+      "text": "How Much Does Your Cough Affect You?",
+      "required": true,
+      "answerOption": [
+        {
+          "valueCoding": {
+            "id": "8e37892c-2f54-4912-8be0-6c9124570642",
+            "code": "0",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "0 - No Burden"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "b764ebc3-25de-4f02-c658-d27d6827a850",
+            "code": "1",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "1 - Minimally"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "230770c1-a162-4a52-9afe-f21e34740a5f",
+            "code": "2",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "2 - Mildly"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "2231e817-6b25-4ac3-bc56-6e76199a0494",
+            "code": "3",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "3 - Moderately"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "0826f1f9-ebce-4c36-8f3f-09931c343e3a",
+            "code": "4",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "4 - Significantly"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "f2209262-7690-49e8-8454-639fef4bef99",
+            "code": "5",
+            "system": "urn:uuid:509be6be-327e-4054-c9c6-9b50054436f0",
+            "display": "5 - Extremely"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "e61212d0-2522-4f3c-faba-73bb9044c357",
+      "type": "choice",
+      "text": "Which of the following factors trigger or worsen your cough? (Select all that apply)",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ValueSet/questionnaire-item-control",
+                "code": "check-box"
+              }
+            ]
+          }
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "id": "e17de663-b884-4eae-8104-18b16cbf5268",
+            "code": "air-pollution",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Air pollution"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "18c88d31-8384-4f44-9f7c-6bfc095b17ac",
+            "code": "cold-weather",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Cold weather"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "f770be51-52eb-47c9-eca5-3b24ceaeb9b6",
+            "code": "dust-or-allergens",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Dust or allergens"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "384dc0d1-36a2-460e-a47f-5eaa70ca5d94",
+            "code": "exercise",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Exercise"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "f1358fe5-6a19-4866-921c-d37e3d531e7a",
+            "code": "pollen",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Pollen"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "8dd2f7e9-d759-4e14-85a3-51bb935ca434",
+            "code": "smoke",
+            "system": "urn:uuid:65e74bde-f47b-4431-8c61-57b63ebd15db",
+            "display": "Smoke"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "c3c06e22-b39e-4948-97a3-84eac152f294",
+      "type": "open-choice",
+      "text": "How has your cough impacted your quality of life?",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "id": "060145ac-5648-47df-f044-45ced094af05",
+            "code": "limitations-in-performing-usual-household-activities",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Limitations in performing usual household activities"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "7375da5a-8374-484d-8ea7-54a490ebeac1",
+            "code": "limitations-in-engaging-in-strenuous-physical-activities",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Limitations in engaging in strenuous physical activities"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "cca84c40-bbd6-4058-e4c6-5c24e42a899e",
+            "code": "limitations-in-participating-in-social-interactions",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Limitations in participating in social interactions"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "512e1a09-7c1f-4cb0-85e6-a74de883cd65",
+            "code": "difficulty-falling-asleep-due-to-coughing",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Difficulty falling asleep due to coughing"
+          }
+        },
+        {
+          "valueCoding": {
+            "id": "870c9fd4-819e-4107-b61a-6c912c619fcd",
+            "code": "sleep-disturbances-caused-by-coughing",
+            "system": "urn:uuid:4fe8dfe1-9d65-456c-e604-436dd10fb8c6",
+            "display": "Sleep disturbances caused by coughing"
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ValueSet/questionnaire-item-control",
+                "code": "check-box"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/CoughSync/Resources/CoughBurdenQuestionnaire.json.license
+++ b/CoughSync/Resources/CoughBurdenQuestionnaire.json.license
@@ -1,0 +1,6 @@
+
+This source file is part of the CoughSync based on the Stanford Spezi Template Application project
+
+SPDX-FileCopyrightText: 2025 Stanford University
+
+SPDX-License-Identifier: MIT

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -81,9 +81,6 @@
         }
       }
     },
-    "Cough Burden Check-In" : {
-
-    },
     "Cough Burden Questionnaire" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -94,6 +91,9 @@
           }
         }
       }
+    },
+    "Cough Sync" : {
+
     },
     "CoughSync" : {
       "localizations" : {
@@ -359,7 +359,7 @@
         }
       }
     },
-    "Tell us about your cough burden every week" : {
+    "Tell us about your cough every week." : {
 
     },
     "The Spezi Framework" : {

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -81,6 +81,30 @@
         }
       }
     },
+    "Cough Burden Check-In" : {
+
+    },
+    "Cough Burden Questionnaire" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cough Burden Questionnaire"
+          }
+        }
+      }
+    },
+    "CoughSync" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spezi\nCoughSync"
+          }
+        }
+      }
+    },
     "Grant Access" : {
       "localizations" : {
         "en" : {
@@ -272,6 +296,7 @@
       }
     },
     "Please fill out the Social Support Questionnaire every day." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -281,22 +306,15 @@
         }
       }
     },
+    "Questionnaires" : {
+
+    },
     "Schedule" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schedule"
-          }
-        }
-      }
-    },
-    "Social Support Questionnaire" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Social Support Questionnaire"
           }
         }
       }
@@ -321,16 +339,6 @@
         }
       }
     },
-    "CoughSync" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spezi\nCoughSync"
-          }
-        }
-      }
-    },
     "Start Questionnaire" : {
       "localizations" : {
         "en" : {
@@ -350,6 +358,9 @@
           }
         }
       }
+    },
+    "Tell us about your cough burden every week" : {
+
     },
     "The Spezi Framework" : {
       "localizations" : {

--- a/CoughSync/Schedule/CoughSyncScheduler.swift
+++ b/CoughSync/Schedule/CoughSyncScheduler.swift
@@ -26,13 +26,13 @@ final class CoughSyncScheduler: Module, DefaultInitializable, EnvironmentAccessi
     func configure() {
         do {
             try scheduler.createOrUpdateTask(
-                id: "social-support-questionnaire",
-                title: "Social Support Questionnaire",
-                instructions: "Please fill out the Social Support Questionnaire every day.",
+                id: "cough-burden-questionnaire",
+                title: "Cough Burden Check-In",
+                instructions: "Tell us about your cough burden every week",
                 category: .questionnaire,
-                schedule: .daily(hour: 8, minute: 0, startingAt: .today)
+                schedule: .weekly(hour: 8, minute: 0, startingAt: .today)
             ) { context in
-                context.questionnaire = Bundle.main.questionnaire(withName: "SocialSupportQuestionnaire")
+                context.questionnaire = Bundle.main.questionnaire(withName: "CoughBurdenQuestionnaire")
             }
         } catch {
             viewState = .error(AnyLocalizedError(error: error, defaultErrorDescription: "Failed to create or update scheduled tasks."))

--- a/CoughSync/Schedule/CoughSyncScheduler.swift
+++ b/CoughSync/Schedule/CoughSyncScheduler.swift
@@ -26,9 +26,9 @@ final class CoughSyncScheduler: Module, DefaultInitializable, EnvironmentAccessi
     func configure() {
         do {
             try scheduler.createOrUpdateTask(
-                id: "cough-burden-questionnaire",
-                title: "Cough Burden Check-In",
-                instructions: "Tell us about your cough burden every week",
+                id: "cough-sync-questionnaire",
+                title: "Cough Sync",
+                instructions: "Tell us about your cough every week.",
                 category: .questionnaire,
                 schedule: .weekly(hour: 8, minute: 0, startingAt: .today)
             ) { context in

--- a/CoughSync/Schedule/ScheduleView.swift
+++ b/CoughSync/Schedule/ScheduleView.swift
@@ -32,7 +32,7 @@ struct ScheduleView: View {
                     }
                 }
             }
-                .navigationTitle("Schedule")
+                .navigationTitle("Questionnaires")
                 .viewStateAlert(state: $scheduler.viewState)
                 .sheet(item: $presentedEvent) { event in
                     EventView(event)

--- a/CoughSyncUITests/SchedulerTests.swift
+++ b/CoughSyncUITests/SchedulerTests.swift
@@ -33,39 +33,42 @@ class SchedulerTests: XCTestCase {
         XCTAssertTrue(app.buttons["Start Questionnaire"].waitForExistence(timeout: 2))
         app.buttons["Start Questionnaire"].tap()
         
-        XCTAssertTrue(app.staticTexts["Social Support"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["In the last 2 weeks, how many times a day have you had coughing bouts?"].waitForExistence(timeout: 2))
         XCTAssertTrue(app.navigationBars.buttons["Cancel"].exists)
 
-        XCTAssertTrue(app.staticTexts["None of the time"].exists)
-        let noButton = app.staticTexts["None of the time"]
+        XCTAssertTrue(app.staticTexts["7 - None"].exists)
+        let noButton = app.staticTexts["7 - None"]
 
         let nextButton = app.buttons["Next"]
-
-        for _ in 1...4 {
-            XCTAssertFalse(nextButton.isEnabled)
-            noButton.tap()
-            XCTAssertTrue(nextButton.isEnabled)
-            nextButton.tap()
-            usleep(500_000)
-        }
-
-        XCTAssert(app.staticTexts["What is your age?"].waitForExistence(timeout: 0.5))
-        XCTAssert(app.textFields["Tap to answer"].exists)
-        try app.textFields["Tap to answer"].enter(value: "25")
-        app.buttons["Done"].tap()
-
-        XCTAssert(nextButton.isEnabled)
+        XCTAssertFalse(nextButton.isEnabled)
+        noButton.tap()
         nextButton.tap()
-
-        XCTAssert(app.staticTexts["What is your preferred contact method?"].waitForExistence(timeout: 0.5))
-        XCTAssert(app.staticTexts["E-mail"].exists)
-        app.staticTexts["E-mail"].tap()
-
-        XCTAssert(nextButton.isEnabled)
+        
+        XCTAssertTrue(
+            app.staticTexts["In the last 2 weeks, which of the following factors triggered or worsened your cough?"]
+                .waitForExistence(timeout: 2)
+        )
+        XCTAssertTrue(app.staticTexts["Air pollution"].exists)
+        let airPollutionButton = app.staticTexts["Air pollution"]
+        airPollutionButton.tap()
         nextButton.tap()
-
-        XCTAssert(app.staticTexts["Thank you for taking the survey!"].waitForExistence(timeout: 0.5))
-        XCTAssert(app.buttons["Done"].exists)
+        
+        XCTAssertTrue(app.staticTexts["In the last 2 weeks, have you had a lot of energy?"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["7 - None of the time"].exists)
+        let energyButton = app.staticTexts["7 - None of the time"]
+        energyButton.tap()
+        nextButton.tap()
+        
+        XCTAssertTrue(app.staticTexts["In the last 2 weeks, has your cough disturbed your sleep?"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["7 - None of the time"].exists)
+        let sleepButton = app.staticTexts["7 - None of the time"]
+        sleepButton.tap()
+        nextButton.tap()
+        
+        XCTAssertTrue(app.staticTexts["In the last 2 weeks, my cough has interfered with my job, or other daily tasks."].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["7 - None of the time"].exists)
+        let dailyTasksButton = app.staticTexts["7 - None of the time"]
+        dailyTasksButton.tap()
         app.buttons["Done"].tap()
 
         XCTAssert(app.staticTexts["Completed"].waitForExistence(timeout: 0.5))


### PR DESCRIPTION
# Cough Sync Questionnaire

## :recycle: Current situation & Problem
* Adding cough burden questionnaire as described in this [issue](https://github.com/CS342/2025-CoughSync/issues/7). 


## :gear: Release Notes 
* Added UI support for a weekly questionnaire on cough burden. 


## :books: Documentation
Example flow:
<img src="https://github.com/user-attachments/assets/137d2a96-18fb-4221-8e41-44123920a4ea" alt="drawing" width="200"/> <img src="https://github.com/user-attachments/assets/e4798058-6329-474c-be2d-c2334fc8a1c2" alt="drawing" width="200"/> <img src="https://github.com/user-attachments/assets/98135c81-ebb4-4eb6-9634-d076bc00ff62" alt="drawing" width="200"/>
<img src="https://github.com/user-attachments/assets/70d63745-fd50-4da8-9cf6-e3924cf19d1a" alt="drawing" width="200"/> <img src="https://github.com/user-attachments/assets/e0db9ee2-71af-416c-801d-97b164cd46b2" alt="drawing" width="200"/> <img src="https://github.com/user-attachments/assets/3ef53db5-c711-40eb-9a5c-8f8832ee56c7" alt="drawing" width="200"/> <img src="https://github.com/user-attachments/assets/1304ca17-cc09-42cc-820d-b731598c374b" alt="drawing" width="200"/>


## :white_check_mark: Testing
* Modified the `SchedulerTests` to make sure the questionnaire is filled up properly.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
