### PR TITLE
Cough Detector

### DIFF
--- a/CoughSync.xcodeproj/project.pbxproj
+++ b/CoughSync.xcodeproj/project.pbxproj
@@ -148,9 +148,9 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		0665A4212D5C2D180055D1B2 /* CoughVisualization */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CoughVisualization; sourceTree = "<group>"; };
 		252FC3102D5DC6520043712C /* CoughDetection */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CoughDetection; sourceTree = "<group>"; };
 		252FC3112D5DC7760043712C /* CoughView */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CoughView; sourceTree = "<group>"; };
-		0665A4212D5C2D180055D1B2 /* CoughVisualization */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CoughVisualization; sourceTree = "<group>"; };
 		4913AC9F2D5C4CF40030C90D /* Models */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Models; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
@@ -387,9 +387,9 @@
 				56E7083D2BB06FCA00B08F0A /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
+				0665A4212D5C2D180055D1B2 /* CoughVisualization */,
 				252FC3102D5DC6520043712C /* CoughDetection */,
 				252FC3112D5DC7760043712C /* CoughView */,
-				0665A4212D5C2D180055D1B2 /* CoughVisualization */,
 				4913AC9F2D5C4CF40030C90D /* Models */,
 			);
 			name = CoughSync;

--- a/CoughSync/CoughDetection/CoughDetectionConfiguration.swift
+++ b/CoughSync/CoughDetection/CoughDetectionConfiguration.swift
@@ -1,0 +1,41 @@
+//
+//  CoughDetectionConfiguration.swift
+//  CoughSync
+//
+//  Created by Miguel Fuentes on 2/23/25.
+//
+
+import CoreMedia
+import Foundation
+
+
+/// Configuration parameters for the cough detection analysis.
+///
+/// This struct defines the settings for analyzing audio streams to detect coughs,
+/// including the analysis window size, overlap factor, and timescale for processing.
+///
+/// - Parameters:
+///   - `windowSize`: The duration of each analysis window in seconds.
+///   - `overlapFactor`: The proportion of overlap between consecutive windows, ranging from `0.0` (no overlap) to `1.0` (complete overlap).
+///   - `timescale`: The timescale representing the number of samples per second, typically aligned with the audio sample rate.
+struct CoughDetectionConfiguration {
+    let windowSize: Double  // In seconds
+    let overlapFactor: Double  // 0.0 - 1.0
+    var timescale: CMTimeScale // Default timescale (samples per second)
+    
+    /// Initializes a new configuration for cough detection analysis.
+    ///
+    /// - Parameters:
+    ///   - `windowSize`: The duration of each analysis window in seconds. Default is `1.0` second.
+    ///   - `overlapFactor`: The fraction of overlap between analysis windows. Default is `0.5` (50% overlap).
+    ///   - `timescale`: The timescale defining the number of samples per second. Default is `48,000` (common for high-quality audio).
+    init(
+        windowSize: Double = 1.0,
+        overlapFactor: Double = 0.5,
+        timescale: CMTimeScale = 48_000
+    ) {
+        self.windowSize = windowSize
+        self.overlapFactor = overlapFactor
+        self.timescale = timescale
+    }
+}

--- a/CoughSync/CoughDetection/CoughDetectionConfiguration.swift
+++ b/CoughSync/CoughDetection/CoughDetectionConfiguration.swift
@@ -1,4 +1,11 @@
 //
+
+// This source file is part of the CoughSync based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
 //  CoughDetectionConfiguration.swift
 //  CoughSync
 //

--- a/CoughSync/CoughDetection/CoughDetectionViewModel.swift
+++ b/CoughSync/CoughDetection/CoughDetectionViewModel.swift
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-//  SoundDetectionViewModel.swift
+//  CoughDetectionViewModel.swift
 //  CoughSync
 //
 //  Created by Ethan Bell on 12/2/2025.
@@ -20,8 +20,8 @@ import SoundAnalysis
 
 @Observable
 @MainActor
-class SoundDetectionViewModel {
-    @ObservationIgnored let soundAnalysisManager = SoundAnalysisManager.shared
+class CoughDetectionViewModel {
+    @ObservationIgnored let coughAnalysisManager = CoughAnalysisManager.shared
     
     @ObservationIgnored var lastTime: Double = 0
     
@@ -67,12 +67,12 @@ class SoundDetectionViewModel {
                 }
             )
         
-        soundAnalysisManager.startSoundClassification(subject: classificationSubject)
+        coughAnalysisManager.startCoughDetection(subject: classificationSubject)
     }
     
     func stopListening() {
         lastTime = 0
         identifiedSound = nil
-        soundAnalysisManager.stopSoundClassification()
+        coughAnalysisManager.stopCoughDetection()
     }
 }

--- a/CoughSync/CoughView/CoughModelView.swift
+++ b/CoughSync/CoughView/CoughModelView.swift
@@ -16,7 +16,7 @@
 import SwiftUI
 
 struct CoughModelView: View {
-    @State var viewModel = SoundDetectionViewModel()
+    @State var viewModel = CoughDetectionViewModel()
     
     var body: some View {
         VStack {


### PR DESCRIPTION
# Cough Detector

## :recycle: Current situation & Problem
Currently, our cough detection approach works the following way:
1. We take a 1-second window of recorded sound.
2. Run the classification model on that window.
3. Classify the window as showing cough or not.

The main problem with this approach are the edge cases. The model is likely misclassify the window as not cough if the cough sound is close to the edges of the window. This introduces error to our detector.


## :gear: Release Notes 
* The new cough detector has a sliding window of configurable size. The default value is 1 second.
* The new cough detector has a configurable overlapping factor. The default value is 0.5.


## :books: Documentation
To solve the problem, we implemented a sliding window with two main hyperparameters:
1. `windowSize`: The recorded sound window in seconds passed to our classifier.
2. `overlapFactor`:  The fraction of overlap between analysis windows. Default is `0.5`


## :white_check_mark: Testing
Because of the nature of the cough classification feature, we don't add automated tests to this feature. Instead, we manually tested the app with different hyperparameters to find a balance between precision and battery efficiency.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
