### PR TITLE
Dashboard2

### DIFF
--- a/CoughSync.xcodeproj/project.pbxproj
+++ b/CoughSync.xcodeproj/project.pbxproj
@@ -701,7 +701,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				492A12BA2D7A2C2800B7C2DD /* CoughTests.swift in Sources */,
-				492A131C2D7A9AA500B7C2DD /* SummaryView.swift in Sources */,
 				492A12E82D7A485B00B7C2DD /* CoughClass.swift in Sources */,
 				492A12EB2D7A612000B7C2DD /* QuestionnaireTypeTests.swift in Sources */,
 				492A12F12D7A62A800B7C2DD /* CoughDetectionConfiguration.swift in Sources */,
@@ -839,7 +838,7 @@
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This message should never appear. Please adjust this when you start using location information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This message should never appear. Please adjust this when you start using microphone information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMotionUsageDescription = "This message should never appear. Please adjust this when you start using motion information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This message should never appear. Please adjust this when you start using speecg information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This app requires access to your microphone to record and analyze cough sounds. Your audio data is processed securely and only used for this purpose.";
 				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -1043,7 +1042,7 @@
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This message should never appear. Please adjust this when you start using location information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This message should never appear. Please adjust this when you start using microphone information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMotionUsageDescription = "This message should never appear. Please adjust this when you start using motion information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This message should never appear. Please adjust this when you start using speecg information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This app requires access to your microphone to record and analyze cough sounds. Your audio data is processed securely and only used for this purpose.";
 				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -1090,7 +1089,7 @@
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This message should never appear. Please adjust this when you start using location information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This message should never appear. Please adjust this when you start using microphone information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
 				INFOPLIST_KEY_NSMotionUsageDescription = "This message should never appear. Please adjust this when you start using motion information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This message should never appear. Please adjust this when you start using speecg information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This app requires access to your microphone to record and analyze cough sounds. Your audio data is processed securely and only used for this purpose.";
 				INFOPLIST_KEY_UICoughSynclicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UICoughSynclicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/CoughSync.xcodeproj/project.pbxproj
+++ b/CoughSync.xcodeproj/project.pbxproj
@@ -75,7 +75,7 @@
 		492A12F02D7A625000B7C2DD /* CoughDetectionConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492A12EF2D7A625000B7C2DD /* CoughDetectionConfigurationTests.swift */; };
 		492A12F12D7A62A800B7C2DD /* CoughDetectionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492A12C32D7A31F300B7C2DD /* CoughDetectionConfiguration.swift */; };
 		492A12F42D7A644B00B7C2DD /* TabNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492A12F32D7A644B00B7C2DD /* TabNavigationTests.swift */; };
-		49437EC12D6D2BA900B6493C /* Dashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49437EC02D6D2BA900B6493C /* Dashboard.swift */; };
+		492A131B2D7A9AA500B7C2DD /* SummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492A13192D7A9AA500B7C2DD /* SummaryView.swift */; };
 		49F06F512D4EDE1500A7E170 /* CoughBurdenQuestionnaire.json.license in Resources */ = {isa = PBXBuildFile; fileRef = 49F06F502D4EDDF700A7E170 /* CoughBurdenQuestionnaire.json.license */; };
 		49F06F5B2D533E7B00A7E170 /* CoughClassifier.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 49F06F5A2D533E7B00A7E170 /* CoughClassifier.mlmodel */; };
 		49F06F5F2D53468400A7E170 /* CoughClassifier.mlmodel.license in Resources */ = {isa = PBXBuildFile; fileRef = 49F06F5E2D53465E00A7E170 /* CoughClassifier.mlmodel.license */; };
@@ -167,7 +167,7 @@
 		492A12EA2D7A612000B7C2DD /* QuestionnaireTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionnaireTypeTests.swift; sourceTree = "<group>"; };
 		492A12EF2D7A625000B7C2DD /* CoughDetectionConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoughDetectionConfigurationTests.swift; sourceTree = "<group>"; };
 		492A12F32D7A644B00B7C2DD /* TabNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabNavigationTests.swift; sourceTree = "<group>"; };
-		49437EC02D6D2BA900B6493C /* Dashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dashboard.swift; sourceTree = "<group>"; };
+		492A13192D7A9AA500B7C2DD /* SummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryView.swift; sourceTree = "<group>"; };
 		49F06F502D4EDDF700A7E170 /* CoughBurdenQuestionnaire.json.license */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoughBurdenQuestionnaire.json.license; sourceTree = "<group>"; };
 		49F06F5A2D533E7B00A7E170 /* CoughClassifier.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = CoughClassifier.mlmodel; sourceTree = "<group>"; };
 		49F06F5E2D53465E00A7E170 /* CoughClassifier.mlmodel.license */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoughClassifier.mlmodel.license; sourceTree = "<group>"; };
@@ -354,12 +354,12 @@
 			path = CoughVisualization;
 			sourceTree = "<group>";
 		};
-		49437EBF2D6D2B8100B6493C /* Dashboard */ = {
+		492A131A2D7A9AA500B7C2DD /* Summary */ = {
 			isa = PBXGroup;
 			children = (
-				49437EC02D6D2BA900B6493C /* Dashboard.swift */,
+				492A13192D7A9AA500B7C2DD /* SummaryView.swift */,
 			);
-			path = Dashboard;
+			path = Summary;
 			sourceTree = "<group>";
 		};
 		653A2544283387FE005D4D48 = {
@@ -387,7 +387,7 @@
 		653A254F283387FE005D4D48 /* CoughSync */ = {
 			isa = PBXGroup;
 			children = (
-				49437EBF2D6D2B8100B6493C /* Dashboard */,
+				492A131A2D7A9AA500B7C2DD /* Summary */,
 				492A12CD2D7A31F600B7C2DD /* CoughView */,
 				492A12C62D7A31F300B7C2DD /* CoughDetection */,
 				492A12BF2D7A31EA00B7C2DD /* Models */,
@@ -651,6 +651,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				492A131B2D7A9AA500B7C2DD /* SummaryView.swift in Sources */,
 				492A12C72D7A31F300B7C2DD /* CoughAnalysisManager.swift in Sources */,
 				492A12C82D7A31F300B7C2DD /* CoughClass.swift in Sources */,
 				492A12C92D7A31F300B7C2DD /* CoughDetectionConfiguration.swift in Sources */,
@@ -665,7 +666,6 @@
 				A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */,
 				A9A3DCC82C75CBBD00FC9B69 /* FirebaseConfiguration.swift in Sources */,
 				4913AC822D5AC5B80030C90D /* ProfileQuestionnaire.swift in Sources */,
-				49437EC12D6D2BA900B6493C /* Dashboard.swift in Sources */,
 				2FE5DC3729EDD7CA004B9AB4 /* OnboardingFlow.swift in Sources */,
 				2F1AC9DF2B4E840E00C24973 /* CoughSync.docc in Sources */,
 				2FF53D8D2A8729D600042B76 /* CoughSyncStandard.swift in Sources */,
@@ -701,6 +701,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				492A12BA2D7A2C2800B7C2DD /* CoughTests.swift in Sources */,
+				492A131C2D7A9AA500B7C2DD /* SummaryView.swift in Sources */,
 				492A12E82D7A485B00B7C2DD /* CoughClass.swift in Sources */,
 				492A12EB2D7A612000B7C2DD /* QuestionnaireTypeTests.swift in Sources */,
 				492A12F12D7A62A800B7C2DD /* CoughDetectionConfiguration.swift in Sources */,

--- a/CoughSync.xcodeproj/xcshareddata/xcschemes/CoughSync.xcscheme
+++ b/CoughSync.xcodeproj/xcshareddata/xcschemes/CoughSync.xcscheme
@@ -82,10 +82,6 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--debugDetector"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "--showOnboarding"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/CoughSync/CoughDetection/CoughClass.swift
+++ b/CoughSync/CoughDetection/CoughClass.swift
@@ -62,14 +62,4 @@ class CoughCollection {
         let coughToday = coughArray.filter { Calendar.current.isDateInToday($0.timestamp) }.count
         return coughToday
     }
-    
-    /// Calculates the difference between today's and yesterday's cough counts.
-    ///
-    /// - Returns: A positive value if today has more coughs than yesterday,
-    ///            a negative value if today has fewer coughs than yesterday.
-    func coughDiffDay() -> Int {
-        let coughToday = coughArray.filter { Calendar.current.isDateInToday($0.timestamp) }.count
-        let coughYesterday = coughArray.filter { Calendar.current.isDateInYesterday($0.timestamp) }.count
-        return coughToday - coughYesterday
-    }
 }

--- a/CoughSync/CoughDetection/CoughDetectionViewModel.swift
+++ b/CoughSync/CoughDetection/CoughDetectionViewModel.swift
@@ -35,6 +35,7 @@ class CoughDetectionViewModel {
     @ObservationIgnored var lastTime: Double = 0
     
     var detectionStarted = false
+    var detectionStatedDate: Date?
     var coughCollection = CoughCollection()
     var coughCount: Int {
         let coughCount = coughCollection.coughCount

--- a/CoughSync/CoughView/CoughModelView.swift
+++ b/CoughSync/CoughView/CoughModelView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// and displays the current status of the detection process.
 struct CoughModelView: View {
     @Environment(CoughSyncStandard.self) private var standard
-    @State private var viewModel: CoughDetectionViewModel?
+    @Binding var viewModel: CoughDetectionViewModel?
     
     var body: some View {
         VStack {
@@ -30,16 +30,16 @@ struct CoughModelView: View {
                 detectionStatusView()
                 Spacer()
                 microphoneButton()
-                .padding()
+//                .padding()
             } else {
                 // Show a loading indicator
                 ProgressView("Loading...")
             }
         }
-        .onAppear {
-            // Initialize viewModel here when environment is available
-            viewModel = CoughDetectionViewModel(standard: standard)
-        }
+//        .onAppear {
+//            // Initialize viewModel here when environment is available
+//            viewModel = CoughDetectionViewModel(standard: standard)
+//        }
     }
     
     private var microphoneImage: some View {

--- a/CoughSync/CoughView/CoughModelView.swift
+++ b/CoughSync/CoughView/CoughModelView.swift
@@ -20,9 +20,7 @@ import SwiftUI
 /// This view provides a user interface for starting and stopping cough detection
 /// and displays the current status of the detection process.
 struct CoughModelView: View {
-    @Environment(CoughSyncStandard.self) private var standard
     @Binding var viewModel: CoughDetectionViewModel?
-    var startDate: Date?
     
     var body: some View {
         VStack {
@@ -31,18 +29,6 @@ struct CoughModelView: View {
             Spacer()
             microphoneButton()
         }
-    }
-    
-    private var microphoneImage: some View {
-        Image(systemName: viewModel?.detectionStarted == true ? "stop.fill" : "mic.fill")
-            .font(.system(size: 50))
-            .padding(30)
-            .background(viewModel?.detectionStarted == true ? .gray.opacity(0.7) : .blue)
-            .foregroundStyle(.white)
-            .clipShape(Circle())
-            .shadow(color: .gray, radius: 5)
-            .contentTransition(.symbolEffect(.replace))
-            .accessibilityLabel(viewModel?.detectionStarted == true ? "Stop cough detection" : "Start cough detection")
     }
 
     @ViewBuilder

--- a/CoughSync/CoughView/CoughModelView.swift
+++ b/CoughSync/CoughView/CoughModelView.swift
@@ -29,21 +29,7 @@ struct CoughModelView: View {
             Spacer()
             detectionStatusView()
             Spacer()
-            microphoneButton2()
-        }
-    }
-    
-    private func microphoneButton2() -> some View {
-        Button(action: {
-            toggleListening()
-        }) {
-            Text(viewModel?.detectionStarted == true ? "Stop tracking" : "Start tracking")
-                .font(.headline)
-                .padding()
-                .frame(minWidth: 200)
-                .background(viewModel?.detectionStarted == true ? Color.red : Color.blue)
-                .foregroundColor(.white)
-                .cornerRadius(10)
+            microphoneButton()
         }
     }
     
@@ -69,7 +55,7 @@ struct CoughModelView: View {
                     description: Text("Tap below to begin detecting nighttime coughs.")
                 )
             }
-        } else if let predictedSound = viewModel?.identifiedSound {
+        } else if (viewModel?.identifiedSound) != nil {
             VStack(spacing: 10) {
                 ContentUnavailableView(
                     "Tracking in Progress",
@@ -90,6 +76,20 @@ struct CoughModelView: View {
         }
     }
     
+    private func microphoneButton() -> some View {
+        Button(action: {
+            toggleListening()
+        }) {
+            Text(viewModel?.detectionStarted == true ? "Stop tracking" : "Start tracking")
+                .font(.headline)
+                .padding()
+                .frame(minWidth: 200)
+                .background(viewModel?.detectionStarted == true ? Color.red : Color.blue)
+                .foregroundColor(.white)
+                .cornerRadius(10)
+        }
+    }
+    
     private func elapsedTimeString(since startDate: Date) -> String {
         let elapsed = Int(Date().timeIntervalSince(startDate))
         
@@ -98,15 +98,6 @@ struct CoughModelView: View {
         let seconds = elapsed % 60
         
         return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-    }
-
-    
-    private func microphoneButton() -> some View {
-        Button(action: {
-            toggleListening()
-        }, label: {
-            microphoneImage
-        })
     }
     
     private func toggleListening() {

--- a/CoughSync/HomeView.swift
+++ b/CoughSync/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView: View {
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Summary", systemImage: "rectangle.grid.2x2", value: .summary) {
-                if let viewModel = viewModel {
+                if viewModel != nil {
                     SummaryView(
                         presentingAccount: $presentingAccount,
                         viewModel: $viewModel

--- a/CoughSync/HomeView.swift
+++ b/CoughSync/HomeView.swift
@@ -17,16 +17,26 @@ struct HomeView: View {
         case coughDetection
         case coughReport
     }
+    
+    @Environment(CoughSyncStandard.self) private var standard
 
     @AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.summary
     @AppStorage(StorageKeys.tabViewCustomization) private var tabViewCustomization = TabViewCustomization()
 
+    @State private var viewModel: CoughDetectionViewModel?
     @State private var presentingAccount = false
 
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Summary", systemImage: "rectangle.grid.2x2", value: .summary) {
-                SummaryView(presentingAccount: $presentingAccount)
+                if let viewModel = viewModel {
+                    SummaryView(
+                        presentingAccount: $presentingAccount,
+                        viewModel: $viewModel
+                    )
+                } else {
+                    ProgressView("Loading...")
+                }
             }
             .customizationID("home.summary")
             
@@ -44,13 +54,10 @@ struct HomeView: View {
                 CoughReportView()
             }
             .customizationID("home.coughreport")
-            
-            if FeatureFlags.debugDetector {
-                Tab("Cough Detection", systemImage: "speaker.wave.3.fill", value: .coughDetection) {
-                    CoughModelView()
-                }
-                .customizationID("home.coughdetection")
-            }
+        }
+        .onAppear {
+            // Initialize viewModel here when environment is available
+            viewModel = CoughDetectionViewModel(standard: standard)
         }
         .tabViewStyle(.sidebarAdaptable)
         .tabViewCustomization($tabViewCustomization)

--- a/CoughSync/HomeView.swift
+++ b/CoughSync/HomeView.swift
@@ -11,24 +11,24 @@ import SwiftUI
 
 struct HomeView: View {
     enum Tabs: String {
-        case dashboard
+        case summary
         case schedule
         case coughTracking
         case coughDetection
         case coughReport
     }
 
-    @AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.dashboard
+    @AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.summary
     @AppStorage(StorageKeys.tabViewCustomization) private var tabViewCustomization = TabViewCustomization()
 
     @State private var presentingAccount = false
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            Tab("Dashboard", systemImage: "rectangle.grid.2x2", value: .dashboard) {
-                Dashboard(presentingAccount: $presentingAccount)
+            Tab("Summary", systemImage: "rectangle.grid.2x2", value: .summary) {
+                SummaryView(presentingAccount: $presentingAccount)
             }
-            .customizationID("home.dashboard")
+            .customizationID("home.summary")
             
             Tab("Check In", systemImage: "list.clipboard", value: .schedule) {
                 ScheduleView(presentingAccount: $presentingAccount)

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -436,9 +436,6 @@
         }
       }
     },
-    "Start cough detection" : {
-
-    },
     "Start Questionnaire" : {
       "localizations" : {
         "en" : {
@@ -453,9 +450,6 @@
 
     },
     "Starting..." : {
-
-    },
-    "Stop cough detection" : {
 
     },
     "Stop tracking" : {

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "    Tap below to stop detecting coughs.\n    Tracking for %@" : {
+
+    },
     "%@ " : {
 
     },
@@ -473,9 +476,6 @@
       }
     },
     "Tap below to begin detecting nighttime coughs." : {
-
-    },
-    "Tap below to stop detecting coughs.\nTracking for %@" : {
 
     },
     "Tell us about your cough every week." : {

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -174,9 +174,6 @@
     "Daily Coughs (Past 7 Days)" : {
 
     },
-    "Dashboard" : {
-
-    },
     "Day" : {
 
     },
@@ -418,9 +415,6 @@
           }
         }
       }
-    },
-    "Questionnaires" : {
-
     },
     "Schedule" : {
       "extractionState" : "stale",

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -119,12 +119,6 @@
     "Cough Count" : {
 
     },
-    "Cough Count: %lld" : {
-
-    },
-    "Cough Difference: %lld" : {
-
-    },
     "Cough Report" : {
 
     },
@@ -150,9 +144,6 @@
 
     },
     "Coughs Change: " : {
-
-    },
-    "Coughs Today: %lld" : {
 
     },
     "coughs/d" : {
@@ -243,9 +234,6 @@
       }
     },
     "Hourly Coughs (Today)" : {
-
-    },
-    "Identifying Cough..." : {
 
     },
     "Initial Assessment" : {
@@ -362,9 +350,6 @@
         }
       }
     },
-    "No Sound Detected" : {
-
-    },
     "NOTIFICATION_PERMISSIONS_DESCRIPTION" : {
       "localizations" : {
         "en" : {
@@ -413,6 +398,9 @@
         }
       }
     },
+    "Ready for bed?" : {
+
+    },
     "Schedule" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -445,6 +433,9 @@
         }
       }
     },
+    "Start cough detection" : {
+
+    },
     "Start Questionnaire" : {
       "localizations" : {
         "en" : {
@@ -455,10 +446,16 @@
         }
       }
     },
-    "Start sound detection" : {
+    "Start tracking" : {
 
     },
-    "Stop sound detection" : {
+    "Starting..." : {
+
+    },
+    "Stop cough detection" : {
+
+    },
+    "Stop tracking" : {
 
     },
     "Summary" : {
@@ -475,7 +472,10 @@
         }
       }
     },
-    "Tap the microphone to start detecting" : {
+    "Tap below to begin detecting nighttime coughs." : {
+
+    },
+    "Tap below to stop detecting coughs.\nTracking for %@" : {
 
     },
     "Tell us about your cough every week." : {
@@ -509,6 +509,9 @@
 
     },
     "Today" : {
+
+    },
+    "Tracking in Progress" : {
 
     },
     "Unsupported Event" : {

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -122,9 +122,6 @@
     "Cough Count: %lld" : {
 
     },
-    "Cough Detection" : {
-
-    },
     "Cough Difference: %lld" : {
 
     },

--- a/CoughSync/Schedule/ScheduleView.swift
+++ b/CoughSync/Schedule/ScheduleView.swift
@@ -32,7 +32,7 @@ struct ScheduleView: View {
                     }
                 }
             }
-                .navigationTitle("Questionnaires")
+                .navigationTitle("Check In")
                 .viewStateAlert(state: $scheduler.viewState)
                 .sheet(item: $presentedEvent) { event in
                     EventView(event)

--- a/CoughSync/SharedContext/FeatureFlags.swift
+++ b/CoughSync/SharedContext/FeatureFlags.swift
@@ -25,7 +25,4 @@ enum FeatureFlags {
     ///
     /// Requires ``disableFirebase`` to be `false`.
     static let setupTestAccount = CommandLine.arguments.contains("--setupTestAccount")
-    
-//    static let debugDetector = CommandLine.arguments.contains("--debugDetector")
-    static let debugDetector = true
 }

--- a/CoughSync/Summary/SummaryView.swift
+++ b/CoughSync/Summary/SummaryView.swift
@@ -7,7 +7,7 @@
 //
 
 //
-//  Dashboard.swift
+//  SummaryView.swift
 //  CoughSync
 //
 //  Created by Miguel Fuentes on 2/24/25.
@@ -20,12 +20,12 @@ import SpeziSchedulerUI
 import SpeziViews
 import SwiftUI
 
-/// `Dashboard` is a view that displays a summary of cough detection data.
+/// `SummaryView` is a view that displays a summary of cough detection data.
 ///
 /// This view provides a summary of cough detection data, including the number of coughs detected
 /// today, this week, and this month. It also displays a visual representation of the cough count
 /// and a trend indicator.
-struct Dashboard: View {
+struct SummaryView: View {
     @Environment(Account.self) private var account: Account?
     @Environment(CoughSyncStandard.self) private var standard
     @Binding var presentingAccount: Bool
@@ -146,5 +146,5 @@ struct Dashboard: View {
 }
 
 #Preview {
-    Dashboard(presentingAccount: .constant(false))
+    SummaryView(presentingAccount: .constant(false))
 }

--- a/CoughSync/Summary/SummaryView.swift
+++ b/CoughSync/Summary/SummaryView.swift
@@ -29,33 +29,25 @@ struct SummaryView: View {
     @Environment(Account.self) private var account: Account?
     @Environment(CoughSyncStandard.self) private var standard
     @Binding var presentingAccount: Bool
-    @State private var viewModel: CoughDetectionViewModel?
+    @Binding var viewModel: CoughDetectionViewModel?
     @State private var previousCoughCount: Int = 0
     
     var body: some View {
         NavigationStack {
             ScrollView {
-                if let viewModel = viewModel {
-                    VStack(spacing: 20) {
-                        coughSummaryCard()
-                        coughStats()
-                        Divider()
-                    }
-                    .padding()
-                } else {
-                    // Show a loading indicator or placeholder
-                    ProgressView("Loading...")
+                VStack(spacing: 20) {
+                    coughSummaryCard()
+                    coughStats()
+                    Divider()
+                    CoughModelView(viewModel: $viewModel)
                 }
+                .padding()
             }
             .navigationTitle("Summary")
             .toolbar {
                 if account != nil {
                     AccountButton(isPresented: $presentingAccount)
                 }
-            }
-            .onAppear {
-                // Initialize viewModel here when environment is available
-                viewModel = CoughDetectionViewModel(standard: standard)
             }
             .onAppear {
                 previousCoughCount = viewModel?.coughCount ?? 0
@@ -66,8 +58,12 @@ struct SummaryView: View {
         }
     }
     
-    init(presentingAccount: Binding<Bool>) {
+    init(
+        presentingAccount: Binding<Bool>,
+        viewModel: Binding<CoughDetectionViewModel?>
+    ) {
         self._presentingAccount = presentingAccount
+        self._viewModel = viewModel
     }
     
     @ViewBuilder
@@ -146,5 +142,10 @@ struct SummaryView: View {
 }
 
 #Preview {
-    SummaryView(presentingAccount: .constant(false))
+    SummaryView(
+        presentingAccount: .constant(false),
+        viewModel: .constant(CoughDetectionViewModel(
+            standard: CoughSyncStandard()
+        ))
+    )
 }

--- a/CoughSync/Summary/SummaryView.swift
+++ b/CoughSync/Summary/SummaryView.swift
@@ -27,7 +27,6 @@ import SwiftUI
 /// and a trend indicator.
 struct SummaryView: View {
     @Environment(Account.self) private var account: Account?
-    @Environment(CoughSyncStandard.self) private var standard
     @Binding var presentingAccount: Bool
     @Binding var viewModel: CoughDetectionViewModel?
     @State private var previousCoughCount: Int = 0

--- a/CoughSyncUITests/OnboardingTests.swift
+++ b/CoughSyncUITests/OnboardingTests.swift
@@ -188,7 +188,7 @@ extension XCUIApplication {
     
     fileprivate func assertOnboardingComplete() {
         let tabBar = tabBars["Tab Bar"]
-        XCTAssertTrue(tabBar.buttons["Dashboard"].waitForExistence(timeout: 2))
+        XCTAssertTrue(tabBar.buttons["Summary"].waitForExistence(timeout: 2))
         XCTAssertTrue(tabBar.buttons["Check In"].exists)
     }
 

--- a/CoughSyncUITests/TabNavigationTests.swift
+++ b/CoughSyncUITests/TabNavigationTests.swift
@@ -32,15 +32,15 @@ final class TabNavigationTests: XCTestCase {
         
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
         
-        // Test Dashboard exists
-        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Dashboard"].exists)
-        app.tabBars["Tab Bar"].buttons["Dashboard"].tap()
+        // Test Summary exists
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Summary"].exists)
+        app.tabBars["Tab Bar"].buttons["Summary"].tap()
         XCTAssertTrue(app.staticTexts["Summary"].waitForExistence(timeout: 2))
         
         // Test Check In exists
         XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Check In"].exists)
         app.tabBars["Tab Bar"].buttons["Check In"].tap()
-        XCTAssertTrue(app.staticTexts["Questionnaires"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Check In"].waitForExistence(timeout: 2))
         
         // Test Cough Tracking exists
         XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Cough Tracking"].exists)


### PR DESCRIPTION
# Simplifying Dashboard

## :recycle: Current situation & Problem
* Currently, we have different tabs for the summary and the action of starting cough detection. This increases the burden of users to start cough tracking at night.


## :gear: Release Notes 
* Now the summary and cough tracking session views are in the same summary page.


## :books: Documentation
<img width="150" alt="Screenshot 2025-03-07 at 12 49 43 PM" src="https://github.com/user-attachments/assets/990dee4b-b121-4299-b0f3-1457d579c144" />
<img width="150" alt="Screenshot 2025-03-07 at 12 49 54 PM" src="https://github.com/user-attachments/assets/7d747d14-9993-4c18-b4d5-e5ee140a2177" />



## :white_check_mark: Testing
* Tests covered in a previous PR.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
