### PR TITLE
Improved UI for NotificationPermissions

### DIFF
--- a/CoughSync/Onboarding/HealthKitPermissions.swift
+++ b/CoughSync/Onboarding/HealthKitPermissions.swift
@@ -28,7 +28,7 @@ struct HealthKitPermissions: View {
                     )
                     Spacer()
                     Image(systemName: "heart.text.square.fill")
-                        .font(.system(size: 150))
+                        .font(.system(size: 130))
                         .foregroundColor(.accentColor)
                         .accessibilityHidden(true)
                     Text("HEALTHKIT_PERMISSIONS_DESCRIPTION")

--- a/CoughSync/Onboarding/NotificationPermissions.swift
+++ b/CoughSync/Onboarding/NotificationPermissions.swift
@@ -17,7 +17,12 @@ struct NotificationPermissions: View {
     @Environment(\.requestNotificationAuthorization) private var requestNotificationAuthorization
 
     @State private var notificationProcessing = false
-    @State private var notifTime = Date()
+    @State private var notifTime: Date = {
+        var components = DateComponents()
+        components.hour = 20 // 8 PM
+        components.minute = 0
+        return Calendar.current.date(from: components) ?? Date()
+    }()
     
     var body: some View {
         OnboardingView(
@@ -25,25 +30,20 @@ struct NotificationPermissions: View {
                 VStack {
                     OnboardingTitleView(
                         title: "Notifications",
-                        subtitle: "Spezi Scheduler Notifications."
+                        subtitle: "CoughSync helps you monitor your cough while you sleep."
                     )
                     Spacer()
                     Image(systemName: "bell.square.fill")
-                        .font(.system(size: 150))
+                        .font(.system(size: 130))
                         .foregroundColor(.accentColor)
                         .accessibilityHidden(true)
                     Text("NOTIFICATION_PERMISSIONS_DESCRIPTION")
                         .multilineTextAlignment(.center)
-                        .padding(.vertical, 16)
-                    Text("Set your preferred time to receive your daily reminder to start recording (before going to sleep!)")
-                        .font(.headline)
-                        .padding(.top, 16)
+                        .padding(.vertical, 2)
                     DatePicker("Choose Reminder Time", selection: $notifTime, displayedComponents: .hourAndMinute)
                         .datePickerStyle(WheelDatePickerStyle())
                         .labelsHidden()
-                        .padding()
-                    
-                    Spacer()
+                        .scaleEffect(0.8)
                 }
             }, actionView: {
                 OnboardingActionsView(

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -165,6 +165,9 @@
         }
       }
     },
+    "CoughSync helps you monitor your cough while you sleep." : {
+
+    },
     "Daily Coughs (Past 7 Days)" : {
 
     },
@@ -364,7 +367,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The Spezi Scheduler module enables to send out local notifications when a new event of a task is scheduled."
+            "value" : "Set your preferred time to receive your daily reminder to start recording (before going to sleep!)"
           }
         }
       }
@@ -421,9 +424,6 @@
         }
       }
     },
-    "Set your preferred time to receive your daily reminder to start recording (before going to sleep!)" : {
-
-    },
     "Spezi Modules" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -436,6 +436,7 @@
       }
     },
     "Spezi Scheduler Notifications." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/CoughSync/Summary/SummaryView.swift
+++ b/CoughSync/Summary/SummaryView.swift
@@ -148,7 +148,7 @@ struct SummaryView: View {
     @ViewBuilder
     private func statusCircle() -> some View {
         let change = viewModel?.coughCount ?? 0 - previousCoughCount
-        let color: Color = change > 0 ? .red : (change < 0 ? .green : .blue)
+        let color: Color = change > 0 ? .yellow : (change < 0 ? .green : .blue)
         let trendSymbol = change > 0 ? "↑" : (change < 0 ? "↓" : "–")
         
         Circle()


### PR DESCRIPTION
# *Name of the PR*

## :recycle: Current situation & Problem
* Notification permissions screen was not fitting and required scrolling.


## :gear: Release Notes 
* Now the permissions screen fits without scrolling.


## :books: Documentation
* This is part of the original notifications, so no more documentation was needed.


## :white_check_mark: Testing
*Notifications are already tested.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
