### PR TITLE
Fix deployment

### DIFF
--- a/CoughSync/Supporting Files/Info.plist
+++ b/CoughSync/Supporting Files/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
 	<key>CFBundleAllowMixedLocalizations</key>
 	<true/>
 	<key>FirebaseAppDelegateProxyEnabled</key>

--- a/CoughSyncTests/CoughSyncTests.swift
+++ b/CoughSyncTests/CoughSyncTests.swift
@@ -10,7 +10,7 @@
 import XCTest
 
 
-class CoughDashboardTests: XCTestCase {
+class CoughSyncTests: XCTestCase {
     // Removing the testContactsCount test as it references a non-existent Contacts class
     
     // MARK: - CoughCollection Tests


### PR DESCRIPTION
# Fix Deployment

## :recycle: Current situation & Problem
*In the beta deployment, there is an error which prevents the app to be deployed on TestFlight
```
[ContentDelivery.Uploader.6000023481C0] Validation failed (409) Missing Info.plist value. The Info.plist key 'BGTaskSchedulerPermittedIdentifiers' must contain a list of identifiers used to submit and handle tasks when 'UIBackgroundModes' has a value of 'processing'. For more information, refer to the Information Property List Key Reference at https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html. (ID: a7a4a395-620b-4bec-be2c-bb13f995d71d)
```


## :gear: Release Notes 
*No major change to the application


## :books: Documentation
* No documentation change needed


## :white_check_mark: Testing
* This cannot be tested.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
