### PR TITLE
Phone Charge Notification

### DIFF
--- a/CoughSync/CoughView/CoughModelView.swift
+++ b/CoughSync/CoughView/CoughModelView.swift
@@ -6,21 +6,12 @@
 // SPDX-License-Identifier: MIT
 //
 
-//  CoughModelView.swift
-//  CoughSync
-//
-//  Created by Ethan Bell on 12/2/2025.
-//
-
 import Spezi
 import SwiftUI
 
-/// A view that displays the cough detection model and user interface.
-///
-/// This view provides a user interface for starting and stopping cough detection
-/// and displays the current status of the detection process.
 struct CoughModelView: View {
     @Binding var viewModel: CoughDetectionViewModel?
+    @State private var showChargingReminder = false
     
     var body: some View {
         VStack {
@@ -30,15 +21,19 @@ struct CoughModelView: View {
             microphoneButton()
                 .animation(.easeInOut(duration: 0.3), value: viewModel?.detectionStarted)
                 .padding(.bottom, 50)
-            
             Spacer()
         }
         .frame(maxHeight: .infinity, alignment: .bottom)
+        .alert("Keep Your Phone Plugged In", isPresented: $showChargingReminder) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("For accurate cough tracking throughout the night, please keep your phone plugged in and charging.")
+        }
     }
 
     @ViewBuilder
     private func detectionStatusView() -> some View {
-        ZStack { // this keeps elements in stack without shifting layout
+        ZStack {
             if viewModel?.detectionStarted == false {
                 ContentUnavailableView(
                     "Ready for bed?",
@@ -52,7 +47,7 @@ struct CoughModelView: View {
                     description: Text("""
                     Tap below to stop detecting coughs.
                     Tracking for \(elapsedTimeString(since: viewModel?.detectionStatedDate ?? Date()))
-                """)
+                    """)
                 )
             } else {
                 VStack {
@@ -63,11 +58,11 @@ struct CoughModelView: View {
                         .font(.footnote)
                         .foregroundColor(.gray)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity) // keep everything centred
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color(.systemBackground).opacity(0.8))
             }
         }
-        .frame(height: 193) // keeps button fixed
+        .frame(height: 193)
     }
     
     private func microphoneButton() -> some View {
@@ -79,7 +74,7 @@ struct CoughModelView: View {
                 .foregroundColor(.white)
                 .frame(width: 80, height: 80)
                 .background(viewModel?.detectionStarted == true ? Color.red.gradient : Color.blue.gradient)
-                .clipShape(Circle()) // circle might be more visually appealing?
+                .clipShape(Circle())
                 .shadow(radius: 5)
                 .padding(.top, 10)
         }
@@ -101,6 +96,7 @@ struct CoughModelView: View {
         if viewModel?.detectionStarted == true {
             viewModel?.startListening()
             viewModel?.detectionStatedDate = Date()
+            showChargingReminder = true // Show the alert when tracking starts
         } else {
             viewModel?.stopListening()
         }

--- a/CoughSync/CoughView/CoughModelView.swift
+++ b/CoughSync/CoughView/CoughModelView.swift
@@ -27,7 +27,7 @@ struct CoughModelView: View {
         .alert("Keep Your Phone Plugged In", isPresented: $showChargingReminder) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("For accurate cough tracking throughout the night, please keep your phone plugged in and charging.")
+            Text("For accurate cough tracking throughout the night, please keep your phone plugged in and charging close to your bed")
         }
     }
 

--- a/CoughSync/Report/ReportView.swift
+++ b/CoughSync/Report/ReportView.swift
@@ -50,35 +50,6 @@ struct CoughReportView: View {
                     ReportCard(title: "Weekly Report", percentage: weeklyData.percentage, peakTime: weeklyData.peakTime)
                     ReportCard(title: "Monthly Report", percentage: monthlyData.percentage, peakTime: monthlyData.peakTime)
 
-                            NavigationLink(destination: CoughTrackerView()) {
-                                Text("View Cough Frequency Trends →")
-                                    .font(.headline)
-                                    .foregroundColor(.blue)
-                            }
-                            .padding(.top, 10)
-                        }
-                        .padding()
-                        .frame(maxWidth: .infinity)
-                    } else {
-                        ProgressView("Loading report...")
-                            .padding()
-                    }
-                }
-            }
-            .onAppear {
-                loadCoughData()
-            }
-            .navigationTitle("Report")
-            .padding(.horizontal)
-            .toolbar {
-                if account != nil {
-                    AccountButton(isPresented: $presentingAccount)
-                }
-            }
-        }
-    }
-    
-    private func loadCoughData() {
                     NavigationLink(destination: CoughTrackerView()) {
                         Text("View Cough Frequency Trends →")
                             .font(.headline)

--- a/CoughSync/Report/ReportView.swift
+++ b/CoughSync/Report/ReportView.swift
@@ -40,7 +40,7 @@ struct CoughReportView: View {
                         .padding()
                         .frame(maxWidth: .infinity)
                     } else {
-                        ProgressView("Loading cough data...")
+                        ProgressView("Loading report...")
                             .padding()
                     }
                 }

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -1,9 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "    Tap below to stop detecting coughs.\n    Tracking for %@" : {
-
-    },
     "%@ " : {
 
     },
@@ -171,6 +168,9 @@
     "Decrease in coughs" : {
 
     },
+    "For accurate cough tracking throughout the night, please keep your phone plugged in and charging." : {
+
+    },
     "Get Started" : {
 
     },
@@ -314,6 +314,9 @@
         }
       }
     },
+    "Keep Your Phone Plugged In" : {
+
+    },
     "Learn More" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -381,6 +384,9 @@
           }
         }
       }
+    },
+    "OK" : {
+
     },
     "Onboarding" : {
       "extractionState" : "stale",
@@ -483,6 +489,9 @@
       }
     },
     "Tap below to begin detecting nighttime coughs." : {
+
+    },
+    "Tap below to stop detecting coughs.\nTracking for %@" : {
 
     },
     "Tell us about your cough every week." : {

--- a/CoughSync/Resources/Localizable.xcstrings
+++ b/CoughSync/Resources/Localizable.xcstrings
@@ -168,7 +168,7 @@
     "Decrease in coughs" : {
 
     },
-    "For accurate cough tracking throughout the night, please keep your phone plugged in and charging." : {
+    "For accurate cough tracking throughout the night, please keep your phone plugged in and charging close to your bed" : {
 
     },
     "Get Started" : {

--- a/CoughSync/Summary/SummaryView.swift
+++ b/CoughSync/Summary/SummaryView.swift
@@ -5,7 +5,6 @@
 //
 // SPDX-License-Identifier: MIT
 //
-//
 //  SummaryView.swift
 //  CoughSync
 //


### PR DESCRIPTION
# *Name of the PR*

## :recycle: Current situation & Problem
Currently, the CoughSync app does not provide a reminder for users to keep their phone plugged in while running nighttime cough detection. Since continuous tracking can drain battery life, users might experience interruptions if their device runs out of charge overnight.

This PR introduces a notification pop-up that appears when the user starts cough detection, reminding them to keep their phone plugged in.


## :gear: Release Notes 

- Feature: Added an alert that reminds users to keep their phone plugged in when they start cough detection.
- Impact: Improves user experience by reducing the chance of tracking interruptions due to battery depletion.



## :white_check_mark: Testing
N/A


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
